### PR TITLE
Fix PLAYLIST_SUPPORT option not working

### DIFF
--- a/ytdlbot/ytdl_bot.py
+++ b/ytdlbot/ytdl_bot.py
@@ -352,8 +352,10 @@ def link_checker(url: str) -> str:
 
     if (
         not PLAYLIST_SUPPORT
-        and re.findall(r"^https://www\.youtube\.com/channel/", Channel.extract_canonical_link(url))
-        or "list" in url
+        and (
+         re.findall(r"^https://www\.youtube\.com/channel/", Channel.extract_canonical_link(url))
+         or "list" in url
+        )
     ):
         return "Playlist or channel links are disabled."
 


### PR DESCRIPTION
Current version contains wrong conditions set for PLAYLIST_SUPPORT option.

It must check:
! PLAYLIST_SUPPORT and (playlists OR-check conditions)

but checking
! PLAYLIST_SUPPORT and playlist1-condition OR playlist2-condition

That's why links containing 'list' word not working even if PLAYLIST_SUPPORT is set to true

Please merge, thank you.
