### PR TITLE
add option for setting custom tmpfile(download) path

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ You can configure all the following environment variables:
 * TOKEN_PRICE: token price per 1 USD
 * GOOGLE_API_KEY: YouTube API key, required for YouTube video subscription.
 * RCLONE_PATH: rclone path to upload files to cloud storage
+* TMPFILE_PATH: tmpfile path(file download path)
+
 ## 3.2 Set up init data
 
 If you only need basic functionality, you can skip this step.

--- a/ytdlbot/config.py
+++ b/ytdlbot/config.py
@@ -66,3 +66,9 @@ RATE_LIMIT = os.getenv("RATE_LIMIT", 20)
 
 SS_YOUTUBE = os.getenv("SS_YOUTUBE", "https://ytdlbot.dmesg.app?token=123456")
 RCLONE_PATH = os.getenv("RCLONE")
+
+# This will set the value for the tmpfile path(download path) if it is set.
+# If TMPFILE is not set, it will return None and use system’s default temporary file path.
+# Please ensure that the directory exists and you have necessary permissions to write to it.
+# If you don't know what this is just leave it as it is.
+TMPFILE_PATH = os.getenv("TMPFILE")

--- a/ytdlbot/tasks.py
+++ b/ytdlbot/tasks.py
@@ -48,6 +48,7 @@ from config import (
     RATE_LIMIT,
     RCLONE_PATH,
     WORKERS,
+    TMPFILE_PATH
 )
 from constant import BotText
 from database import Redis
@@ -193,7 +194,7 @@ def direct_normal_download(client: Client, bot_msg: typing.Union[types.Message, 
     if not filename:
         filename = quote_plus(url)
 
-    with tempfile.TemporaryDirectory(prefix="ytdl-") as f:
+    with tempfile.TemporaryDirectory(prefix="ytdl-", dir=TMPFILE_PATH) as f:
         filepath = f"{f}/{filename}"
         # consume the req.content
         downloaded = 0
@@ -224,7 +225,7 @@ def normal_audio(client: Client, bot_msg: typing.Union[types.Message, typing.Cor
         "Converting to audio...please wait patiently", quote=True
     )
     orig_url: str = re.findall(r"https?://.*", bot_msg.caption)[0]
-    with tempfile.TemporaryDirectory(prefix="ytdl-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="ytdl-", dir=TMPFILE_PATH) as tmp:
         client.send_chat_action(chat_id, enums.ChatAction.RECORD_AUDIO)
         # just try to download the audio using yt-dlp
         filepath = ytdl_download(orig_url, tmp, status_msg, hijack="bestaudio[ext=m4a]")
@@ -261,7 +262,7 @@ def flood_owner_message(client, ex):
 
 def ytdl_normal_download(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str):
     chat_id = bot_msg.chat.id
-    temp_dir = tempfile.TemporaryDirectory(prefix="ytdl-")
+    temp_dir = tempfile.TemporaryDirectory(prefix="ytdl-", dir=TMPFILE_PATH)
 
     video_paths = ytdl_download(url, temp_dir.name, bot_msg)
     logging.info("Download complete.")

--- a/ytdlbot/utils.py
+++ b/ytdlbot/utils.py
@@ -26,6 +26,8 @@ import psutil
 
 from flower_tasks import app
 
+from config import TMPFILE_PATH
+
 inspect = app.control.inspect()
 
 
@@ -219,14 +221,14 @@ def auto_restart():
     for method in method_list:
         if method():
             logging.critical("Bye bye world!☠️")
-            for item in pathlib.Path(tempfile.gettempdir()).glob("ytdl-*"):
+            for item in pathlib.Path(TMPFILE_PATH or tempfile.gettempdir()).glob("ytdl-*"):
                 shutil.rmtree(item, ignore_errors=True)
 
             psutil.Process().kill()
 
 
 def clean_tempfile():
-    for item in pathlib.Path(tempfile.gettempdir()).glob("ytdl-*"):
+    for item in pathlib.Path(TMPFILE_PATH or tempfile.gettempdir()).glob("ytdl-*"):
         if time.time() - item.stat().st_ctime > 3600:
             shutil.rmtree(item, ignore_errors=True)
 


### PR DESCRIPTION
This is the option for setting a custom path as a tmpfile path (file download path). This setting helps when you are going to deploy bot in a restricted environment.