### PR TITLE
Temporary fix for 'msg_id is too low' error

### DIFF
--- a/ytdlbot/downloader.py
+++ b/ytdlbot/downloader.py
@@ -169,12 +169,17 @@ def ytdl_download(url: str, tempdir: str, bm, **kwargs) -> list:
             "--max-concurrent-downloads=16",
             "--split=16",
         ]
-    formats = [
-        # webm , vp9 and av01 are not streamable on telegram, so we'll extract mp4 and not av01 codec
-        "bestvideo[ext=mp4][vcodec!*=av01][vcodec!*=vp09]+bestaudio[ext=m4a]/bestvideo+bestaudio",
-        "bestvideo[vcodec^=avc]+bestaudio[acodec^=mp4a]/best[vcodec^=avc]/best",
-        None,
-    ]
+    if url.startswith("https://drive.google.com"):
+        # Always use the `source` format for Google Drive URLs.
+        formats = ["source"]
+    else:
+        # Use the default formats for other URLs.
+        formats = [
+            # webm , vp9 and av01 are not streamable on telegram, so we'll extract only mp4
+            "bestvideo[ext=mp4][vcodec!*=av01][vcodec!*=vp09]+bestaudio[ext=m4a]/bestvideo+bestaudio",
+            "bestvideo[vcodec^=avc]+bestaudio[acodec^=mp4a]/best[vcodec^=avc]/best",
+            None,
+        ]
     adjust_formats(chat_id, url, formats, hijack)
     if download_instagram(url, tempdir):
         return list(pathlib.Path(tempdir).glob("*"))

--- a/ytdlbot/ytdl_bot.py
+++ b/ytdlbot/ytdl_bot.py
@@ -10,6 +10,7 @@ __author__ = "Benny <benny.think@gmail.com>"
 import contextlib
 import logging
 import os
+from pathlib import Path
 import random
 import re
 import tempfile
@@ -507,8 +508,15 @@ def raw_update(client: Client, update, users, chats):
         payment.add_pay_user([uid, amount, action.charge.provider_charge_id, 0, amount * TOKEN_PRICE])
         client.send_message(uid, f"Thank you {uid}. Payment received: {amount} {action.currency}")
 
+def temp_fix_The_msg_id_is_too_low():
+    current_dir = Path(__file__).parent
+    s_file_path = current_dir / "ytdl-main.session"
+    if os.path.exists(s_file_path):
+        print(f"Deleting session file :", s_file_path)
+        os.remove(s_file_path)
 
 if __name__ == "__main__":
+    temp_fix_The_msg_id_is_too_low()
     MySQL()
     scheduler = BackgroundScheduler(timezone="Asia/Shanghai", job_defaults={"max_instances": 5})
     scheduler.add_job(redis.reset_today, "cron", hour=0, minute=0)


### PR DESCRIPTION
With this commit,
Bot automatically deletes session file if it exist and creates a new one.

This should temporary fix printing
```bash
pyrogram.errors.BadMsgNotification: [16] The msg_id is too low, the client time has to be synchronized.
```
and stops the bot.

Bot log --> [https://pastebin.com/NjBRRPYz](https://pastebin.com/NjBRRPYz)