### PR TITLE
Bump requests from 2.31.0 to 2.32.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ fakeredis==2.22.0
 supervisor==4.2.5
 tgbot-ping==1.0.7
 redis==5.0.4
-requests==2.31.0
+requests==2.32.3
 tqdm==4.66.4
 requests-toolbelt==1.0.0
 ffpb==0.4.1


### PR DESCRIPTION
**Tested ✅**

Updating requests in response to the error,
The conflict is caused by:
```
The user requested requests==2.31.0
yt-dlp 2024.7.2 depends on requests<3 and >=2.32.2
```
![Screenshot_20240704_162320](https://github.com/tgbot-collection/ytdlbot/assets/66342986/317ae210-31ae-4f10-95b1-65e5b3c128e7)

and

![Screenshot_20240704_165010](https://github.com/tgbot-collection/ytdlbot/assets/66342986/ce7411b9-074d-4726-a4ed-74288decff67)

