### PR TITLE
Rename option for `/direct` command

### DIFF
--- a/ytdlbot/tasks.py
+++ b/ytdlbot/tasks.py
@@ -214,12 +214,12 @@ def ytdl_download_entrance(client: Client, bot_msg: types.Message, url: str, mod
             bot_msg.edit_text(f"Download failed!❌\n\n`{traceback.format_exc()[-2000:]}`", disable_web_page_preview=True)
 
 
-def direct_download_entrance(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str):
+def direct_download_entrance(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str, custom_filename):
     if ENABLE_CELERY:
-        direct_normal_download(client, bot_msg, url)
+        direct_normal_download(client, bot_msg, url, custom_filename)
         # direct_download_task.delay(bot_msg.chat.id, bot_msg.id, url)
     else:
-        direct_normal_download(client, bot_msg, url)
+        direct_normal_download(client, bot_msg, url, custom_filename)
 
 
 def leech_download_entrance(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str):
@@ -269,7 +269,7 @@ def audio_entrance(client: Client, bot_msg: types.Message):
         normal_audio(client, bot_msg)
 
 
-def direct_normal_download(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str):
+def direct_normal_download(client: Client, bot_msg: typing.Union[types.Message, typing.Coroutine], url: str, custom_filename):
     chat_id = bot_msg.chat.id
     headers = {
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
@@ -284,7 +284,10 @@ def direct_normal_download(client: Client, bot_msg: typing.Union[types.Message, 
         bot_msg.edit_text(f"Download failed!❌\n\n```{e}```", disable_web_page_preview=True)
         return
 
-    filename = extract_filename(req)
+    if custom_filename:
+        filename = custom_filename
+    else:
+        filename = extract_filename(req)
 
     with tempfile.TemporaryDirectory(prefix="ytdl-", dir=TMPFILE_PATH) as f:
         filepath = f"{f}/{filename}"

--- a/ytdlbot/ytdl_bot.py
+++ b/ytdlbot/ytdl_bot.py
@@ -298,9 +298,12 @@ def direct_handler(client: Client, message: types.Message):
         message.reply_text("Send me a DIRECT LINK.", quote=True)
         return
 
+    url_parts = url.split(" -n ", maxsplit=1)
+    url = url_parts[0].strip()  # Assuming space after -n
+    custom_filename = url_parts[1].strip() if len(url_parts) > 1 else None
     bot_msg = message.reply_text("Request received.", quote=True)
     redis.update_metrics("direct_request")
-    direct_download_entrance(client, bot_msg, url)
+    direct_download_entrance(client, bot_msg, url, custom_filename)
 
 
 @app.on_message(filters.command(["leech"]))


### PR DESCRIPTION
Now `/direct` command support `-n {New_Name}` . 

> While the bot supports identifying many file extensions and add it to the name, it would be better if you could include the extension in the new file name.

Sample
`/direct link -n {new_name}`

![Screenshot_20240831_151829](https://github.com/user-attachments/assets/ef6b7dc8-c26a-4673-9702-73507e532bbb)

![Screenshot_20240831_152455](https://github.com/user-attachments/assets/7d6b4bf3-3186-4859-9ae7-b6f1371652c7)