### PR TITLE
yt-dlp's Python dependencies must be installed using the default group, beginning with 2024.11.04 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/KurimuzonAkuma/pyrogram
 tgcrypto==1.2.5
-yt-dlp==2024.11.04
+yt-dlp[default]==2024.11.04
 APScheduler==3.10.4
 beautifultable==1.1.0
 ffmpeg-python==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/KurimuzonAkuma/pyrogram
 tgcrypto==1.2.5
-yt-dlp==2024.10.22
+yt-dlp==2024.11.04
 APScheduler==3.10.4
 beautifultable==1.1.0
 ffmpeg-python==0.2.0


### PR DESCRIPTION
I missed this with my previous commit.

![Screenshot_20241110_153631](https://github.com/user-attachments/assets/78198051-d03b-400c-86a4-628f5f6a4864)

[https://github.com/yt-dlp/yt-dlp/pull/11255](https://github.com/yt-dlp/yt-dlp/pull/11255)